### PR TITLE
Add a method for introducing a low-order tilt, smoothly warping to data

### DIFF
--- a/docs/tutorials/Divide_by_a_blackbody.ipynb
+++ b/docs/tutorials/Divide_by_a_blackbody.ipynb
@@ -1,0 +1,289 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7a2cd18c",
+   "metadata": {},
+   "source": [
+    "# Divide by a black body\n",
+    "\n",
+    "Often in real-world astronomical applications, we want to see how a stellar spectrum varies in wavelength without the large and omnipresent crest of the black body curve.\n",
+    "\n",
+    "In this tutorial we show how to remove the black body curve from a precomputed model spectrum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bff4637",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gollum.phoenix import PHOENIXSpectrum\n",
+    "from gollum.precomputed_spectrum import PrecomputedSpectrum\n",
+    "from astropy.modeling.physical_models import BlackBody\n",
+    "import astropy.units as u\n",
+    "import numpy as np\n",
+    "%config InlineBackend.figure_format='retina'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57a2e0ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T_eff = 5_700"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e0d7fcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_spectrum = PHOENIXSpectrum(teff=T_eff, logg=4.5, metallicity=0,\n",
+    "                                    wl_lo=0, wl_hi=1e10) # Get the whole spectrum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "979b0e04",
+   "metadata": {},
+   "source": [
+    "The PHOENIX spectra have units of $\\frac{\\mathrm{erg}}{\\mathrm{s\\;cm^2 \\;cm}}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64e6e428",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_spectrum.flux.unit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e165c383",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_spectrum.flux.min()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10288aa0",
+   "metadata": {},
+   "source": [
+    "### Make a black body spectrum with the same temperature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f14268b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackbody_model = BlackBody(temperature=T_eff*u.Kelvin)\n",
+    "blackbody_flux_per_sr = blackbody_model(original_spectrum.wavelength)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "247006ed",
+   "metadata": {},
+   "source": [
+    "The Black Body spectra have units of $\\frac{\\mathrm{erg}}{\\mathrm{s\\;cm^2 \\;Hz \\;sr}}$.  To convert between the two conventions we have to do two things.  First we have to pretend we are standing on the surface of the star, and multiply by $\\pi$ steradians."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a27c90f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackbody_flux_per_Hz = blackbody_flux_per_sr * np.pi * u.steradian"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e050f4f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackbody_flux = blackbody_flux_per_Hz.to(original_spectrum.flux.unit, \n",
+    "                  equivalencies=u.spectral_density(original_spectrum.wavelength))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a04d7688",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blackbody = PrecomputedSpectrum(flux=blackbody_flux, \n",
+    "                                spectral_axis=original_spectrum.wavelength)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b158b8d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = original_spectrum.plot()\n",
+    "blackbody.plot(ax=ax)\n",
+    "\n",
+    "#ax.set_ylim(blackbody.flux.value.min(), original_spectrum.flux.value.max())\n",
+    "ax.set_ylim(1e0, 1e16)\n",
+    "ax.set_yscale('log')\n",
+    "ax.set_ylabel('Flux (erg/s/cm$^3$)');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de95c7b3",
+   "metadata": {},
+   "source": [
+    "The plot spans 16 orders of magnitude-- a huge dynamic range!  Notice that the spectra have similar---but not identical---broadband spectral shapes. They should have the identical area under the curve, by the definition of effective temperature.  Let's see if they do!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b0fccdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.integrate import trapezoid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afe2110c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_flux = trapezoid(original_spectrum.flux, x=original_spectrum.wavelength.to(u.cm))\n",
+    "black_body_flux = trapezoid(blackbody.flux, x=original_spectrum.wavelength.to(u.cm))\n",
+    "\n",
+    "original_flux/black_body_flux"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9de97390",
+   "metadata": {},
+   "source": [
+    "The two spectral models have the same flux to within 1%, which is close enough to identical given that more spectrum resides outside the extent of the plot, and numerical artifacts limitations in the spectral modeling procedure.  Let's compute the ratio spectrum to see how flat the spectrum looks.  We'll first plot it over the same dynamic range as before to emphasize how much more compressed it is."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc9ba890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratio_spectrum = original_spectrum.divide(blackbody)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "999ba02b",
+   "metadata": {},
+   "source": [
+    "The resulting spectrum is a ratio of fluxes with the same units, so it is dimensionless."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c0b1d06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratio_spectrum.flux.unit == u.dimensionless_unscaled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f432582",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = ratio_spectrum.plot();\n",
+    "\n",
+    "ax.set_ylim(1e-12, 1e4)\n",
+    "ax.set_yscale('log')\n",
+    "ax.set_ylabel('Normalized flux');\n",
+    "\n",
+    "ax.axhline(1.0, linestyle='dashed', color='k');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e67a151b",
+   "metadata": {},
+   "source": [
+    "At this dramatic zoom level, the flux looks pretty flat (except for the extreme ultraviolet portion of the spectrum).  Let's zoom in on a region of interest from $8000 - 13000\\; Å$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffea529e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = ratio_spectrum.plot(ylo=0, yhi=1.15);\n",
+    "ax.set_ylabel('Normalized flux');\n",
+    "\n",
+    "ax.axhline(1.0, linestyle='dashed', color='k');\n",
+    "ax.set_xlim(8_000, 13_000);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc91987d",
+   "metadata": {},
+   "source": [
+    "OK, looks good!  We have successfully used the blackbody curve to coarsely flatten the spectrum!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -10,3 +10,5 @@ Getting started
    Exploring the PHOENIX models <PHOENIX_tutorial.ipynb>
 
    Finding a best fit rotational broadening and RV <best_fit_for_fixed_template.ipynb>
+
+   Divide a spectrum by a black body curve <Divide_by_a_blackbody.ipynb>


### PR DESCRIPTION
Wavelength dependent slit losses and broad-band model imperfections mean that often data and models possess slightly different "tilts" from red-to-blue ends of the spectra.  These may be small, or large relative to the problem.  The usual technique is to continuum normalize the data an model discarding any such tilt.  But sometimes you want to compare the spectra head-to-head with whole-spectrum fitting.  In such a case, you can "warp" the model to the data with a low-order polynomial.  

This polynomial happens to be a linear model, so we could hypothetically introduce a design matrix and solve the linear algebra exactly.  Here we simply use some canned routine in the specutils fitting toolbox that does a median filtering pre-process step.  

If we want to turn this into a supported method, we should probably add some checking that the axes have the same sampling, with an option to run `.resample()` on the template.  