### PR TITLE
Experimental new feature--- allow on-the-fly downloading of PHOENIX

### DIFF
--- a/src/gollum/phoenix.py
+++ b/src/gollum/phoenix.py
@@ -9,6 +9,7 @@ PHOENIXSpectrum
 """
 
 import copy
+from turtle import down
 import warnings
 import logging
 from gollum.precomputed_spectrum import PrecomputedSpectrum
@@ -46,6 +47,8 @@ class PHOENIXSpectrum(PrecomputedSpectrum):
         logg (float): The logg label of the PHOENIX model to read in.  Must be on the PHOENIX grid.
         path (str): The path to your local PHOENIX grid library.  You must have the PHOENIX
             grid downloaded locally.  Default: "~/libraries/raw/PHOENIX/"
+        download (bool): **Experimental** Whether or not you want to download the spectra 
+            from the internet.  Requires an internet connection to work.
         wl_lo (float): the bluest wavelength of the models to keep (Angstroms)
         wl_hi (float): the reddest wavelength of the models to keep (Angstroms)
     """
@@ -57,18 +60,19 @@ class PHOENIXSpectrum(PrecomputedSpectrum):
         logg=None,
         metallicity=None,
         path=None,
+        download=False,
         wl_lo=8038,
         wl_hi=12849,
         **kwargs,
     ):
 
-        if path is None:
-            path = "~/libraries/raw/PHOENIX/"
-
         if metallicity is None:
             metallicity = 0.0  # solar by default
 
-        if (teff is not None) & (logg is not None):
+        if path is None:
+            path = "~/libraries/raw/PHOENIX/"
+
+        if download == False:
             base_path = os.path.expanduser(path)
             assert os.path.exists(
                 base_path
@@ -78,6 +82,11 @@ class PHOENIXSpectrum(PrecomputedSpectrum):
             assert os.path.exists(
                 wl_filename
             ), f"You need to place the PHOENIX models in {base_path}"
+        else:
+            wl_filename = "ftp://phoenix.astro.physik.uni-goettingen.de/v2.0/HiResFITS/WAVE_PHOENIX-ACES-AGSS-COND-2011.fits"
+            base_path = "ftp://phoenix.astro.physik.uni-goettingen.de/v2.0/HiResFITS/PHOENIX-ACES-AGSS-COND-2011/"
+
+        if (teff is not None) & (logg is not None):
 
             wl_orig = fits.open(wl_filename)[0].data.astype(np.float64)
 
@@ -93,7 +102,6 @@ class PHOENIXSpectrum(PrecomputedSpectrum):
                 base_path
                 + "/Z{}/lte{:05d}-{:0.2f}{}.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits"
             ).format(metallicity_string, teff, logg, metallicity_string)
-            assert os.path.exists(fn), "Double check that the file {} exists".format(fn)
 
             flux_orig = fits.open(fn)[0].data.astype(np.float64)
             # Units: erg/s/cm^2/cm

--- a/src/gollum/phoenix.py
+++ b/src/gollum/phoenix.py
@@ -9,7 +9,6 @@ PHOENIXSpectrum
 """
 
 import copy
-from turtle import down
 import warnings
 import logging
 from gollum.precomputed_spectrum import PrecomputedSpectrum
@@ -83,6 +82,12 @@ class PHOENIXSpectrum(PrecomputedSpectrum):
                 wl_filename
             ), f"You need to place the PHOENIX models in {base_path}"
         else:
+            log.info(
+                "Experimental feature! Attempting to download PHOENIX models from the internet..."
+            )
+            log.info(
+                "We are using this FTP site: ftp://phoenix.astro.physik.uni-goettingen.de/v2.0/HiResFITS/"
+            )
             wl_filename = "ftp://phoenix.astro.physik.uni-goettingen.de/v2.0/HiResFITS/WAVE_PHOENIX-ACES-AGSS-COND-2011.fits"
             base_path = "ftp://phoenix.astro.physik.uni-goettingen.de/v2.0/HiResFITS/PHOENIX-ACES-AGSS-COND-2011/"
 


### PR DESCRIPTION
So this PR makes it really easy to download a PHOENIX spectrum *on-the-fly*.  Previously a user was required to have an existing pre-downloaded PHOENIX file on their computer.  This local file requirement hampered quick-look operations since our guidance had been to download the entire 100 GB grid, rather than a mere few MB file.

I am very excited about this advance because it will really speed things up for newcomers.  Unfortunately the Sonora files cannot currently support this feature, but we may experiment with new strategies there someday.

Will close #36 