### PR TITLE
Add a resample_to_uniform_in_velocity method

### DIFF
--- a/src/gollum/precomputed_spectrum.py
+++ b/src/gollum/precomputed_spectrum.py
@@ -76,7 +76,7 @@ class PrecomputedSpectrum(Spectrum1D):
             log.warning(
                 "Your velocity sampling appears to be non-uniform  "
                 "at the {:0.4f} km/s level, which could affect future convolution proceses."
-                "  Consider applying the `remap_to_velocity_axis` method.".format(
+                "  Consider applying the `resample_to_uniform_in_velocity` method.".format(
                     velocity_variation
                 )
             )

--- a/tests/test_precomputed.py
+++ b/tests/test_precomputed.py
@@ -47,3 +47,36 @@ def test_basic():
     assert len(new_spec.flux) == len(new_spec.wavelength)
     assert len(new_spec.flux) == len(spec.wavelength)
     assert isinstance(spec, PrecomputedSpectrum)
+
+
+def test_resampling():
+    """Does resampling work?"""
+
+    n_pix = 1000
+    x_vec = np.linspace(10_000, 10_100, n_pix) * u.Angstrom
+    y_continuum = np.ones_like(x_vec.value)
+    y_perturbation = 0.05 * np.sin(2 * np.pi * x_vec.value / 6.0)
+    y_vec = (y_continuum + y_perturbation) * u.dimensionless_unscaled
+    spec = PrecomputedSpectrum(spectral_axis=x_vec, flux=y_vec)
+
+    new_spec = spec.remap_to_velocity_axis()
+
+    assert new_spec is not None
+    assert isinstance(new_spec, Spectrum1D)
+    assert isinstance(new_spec.flux, np.ndarray)
+    assert len(new_spec.wavelength) != len(spec.wavelength)
+
+    new_spec = spec.remap_to_velocity_axis(oversample=3.5)
+
+    assert new_spec is not None
+    assert isinstance(new_spec, Spectrum1D)
+    assert isinstance(new_spec.flux, np.ndarray)
+    assert len(new_spec.wavelength) != len(spec.wavelength)
+
+    # Test undersampling... should log a warning...
+    new_spec = spec.remap_to_velocity_axis(oversample=0.2)
+
+    assert new_spec is not None
+    assert isinstance(new_spec, Spectrum1D)
+    assert isinstance(new_spec.flux, np.ndarray)
+    assert len(new_spec.wavelength) != len(spec.wavelength)

--- a/tests/test_precomputed.py
+++ b/tests/test_precomputed.py
@@ -59,14 +59,14 @@ def test_resampling():
     y_vec = (y_continuum + y_perturbation) * u.dimensionless_unscaled
     spec = PrecomputedSpectrum(spectral_axis=x_vec, flux=y_vec)
 
-    new_spec = spec.remap_to_velocity_axis()
+    new_spec = spec.resample_to_uniform_in_velocity()
 
     assert new_spec is not None
     assert isinstance(new_spec, Spectrum1D)
     assert isinstance(new_spec.flux, np.ndarray)
     assert len(new_spec.wavelength) != len(spec.wavelength)
 
-    new_spec = spec.remap_to_velocity_axis(oversample=3.5)
+    new_spec = spec.resample_to_uniform_in_velocity(oversample=3.5)
 
     assert new_spec is not None
     assert isinstance(new_spec, Spectrum1D)
@@ -74,7 +74,7 @@ def test_resampling():
     assert len(new_spec.wavelength) != len(spec.wavelength)
 
     # Test undersampling... should log a warning...
-    new_spec = spec.remap_to_velocity_axis(oversample=0.2)
+    new_spec = spec.resample_to_uniform_in_velocity(oversample=0.2)
 
     assert new_spec is not None
     assert isinstance(new_spec, Spectrum1D)


### PR DESCRIPTION
Here we implement a "resample_to_uniform_in_velocity" method, necessary for many convolution operations. 

We may want to rethink the verbose name...
Also adds a useful `.velocity_spacing` attribute. 


Closes #35. 