### PR TITLE
Dependency things

### DIFF
--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: [3.8, 3.9, 3.10.0, 3.11]
         numpy-version: [1.22, 1.23, 1.24]
-        astropy-version: [4.3.1, 4.5, 4.8, 5.0, 5.2]
+        astropy-version: [4.3.1, 4.5, 4.8, 5, 5.2]
         specutils-version: [1.6, 1.7, 1.8, 1.9]
         
     steps:

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -47,4 +47,6 @@ jobs:
           timeout_seconds: 15
           max_attempts: 5
           retry_on: error
-          command: npm run pytest tests/test_precomputed.py
+          shell: bash
+          command: |
+            npm run pytest tests/test_precomputed.py

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -21,7 +21,7 @@ jobs:
           repository: OttoStruve/muler_example_data
           path: tests/data
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
-        specutils-version: [1.6, 1.7]
-        astropy-version: [4.3.1, 5.2]
-        numpy-version: [1.21.5, 1.24]
-
+        python-version: [3.8, 3.9, 3.10, 3.11]
+        numpy-version: [1.22, 1.23, 1.24]
+        astropy-version: [4.3.1, 4.5, 4.8, 5.0, 5.2]
+        specutils-version: [1.6, 1.7, 1.8, 1.9]
+        
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -37,9 +37,9 @@ jobs:
       - name: Test PHOENIX
         run: |
           python setup.py develop
-          python -c "import sys; print('Python version: ', sys.version)"
-          python -c "import specutils; print('specutils version: ', specutils.__version__)"
-          python -c "import astropy; print('astropy version: ', astropy.__version__)"
+          python -c "import sys; print(f'Python version: {sys.version}')"
+          python -c "import specutils; print(f'specutils version: {specutils.__version__}')"
+          python -c "import astropy; print(f'astropy version: {astropy.__version__}')"
           pytest tests/test_phoenix.py
       - name: Test Precomputed
         uses: nick-fields/retry@v2

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -45,6 +45,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           timeout_seconds: 30
-          max_attempts: 5
+          max_attempts: 10
           retry_on: error
+          warning_on_retry: false
           command: pytest tests/test_precomputed.py

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10.0, 3.11]
+        python-version: [3.8, 3.9, 3.10.9, 3.11]
         numpy-version: [1.22, 1.23, 1.24]
         astropy-version: [4.3.1, 4.5, 4.8, 5, 5.2]
         specutils-version: [1.6, 1.7, 1.8, 1.9]

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -47,6 +47,4 @@ jobs:
           timeout_seconds: 15
           max_attempts: 5
           retry_on: error
-          command: |
-            echo "Hello"
-            #npm run pytest tests/test_precomputed.py
+          command: pytest tests/test_precomputed.py

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, 3.10.9, 3.11]
         specutils-version: [1.6, 1.7, 1.8, 1.9]
-        
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3
@@ -34,11 +34,17 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Test with pytest
+      - name: Test PHOENIX
         run: |
           python setup.py develop
-          python -c "import sys; print(f'Python version: {sys.version}')"
-          python -c "import specutils; print(f'specutils version: {specutils.__version__}')"
-          python -c "import astropy; print(f'astropy version: {astropy.__version__}')"
+          python -c "import sys; print('Python version: ', sys.version)"
+          python -c "import specutils; print('specutils version: ', specutils.__version__)"
+          python -c "import astropy; print('astropy version: ', astropy.__version__)"
           pytest tests/test_phoenix.py
-          pytest tests/test_precomputed.py
+      - name: Test Precomputed
+        uses: nick-fields/retry@v2.8.3
+        with:
+          timeout_seconds: 15
+          max_attempts: 5
+          retry_on: error
+          command: npm run pytest tests/test_precomputed.py

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test Precomputed
         uses: nick-fields/retry@v2
         with:
-          timeout_seconds: 15
+          timeout_seconds: 30
           max_attempts: 5
           retry_on: error
           command: pytest tests/test_precomputed.py

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Test with pytest
         run: |
           python setup.py develop
-          python -c "import sys; print('Python version: ', sys.version)"
-          python -c "import specutils; print('specutils version: ', specutils.__version__)"
-          python -c "import astropy; print('astropy version: ', astropy.__version__)"
+          python -c "import sys; print(f'Python version: {sys.version}')"
+          python -c "import specutils; print(f'specutils version: {specutils.__version__}')"
+          python -c "import astropy; print(f'astropy version: {astropy.__version__}')"
           pytest tests/test_phoenix.py
           pytest tests/test_precomputed.py

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -42,11 +42,11 @@ jobs:
           python -c "import astropy; print('astropy version: ', astropy.__version__)"
           pytest tests/test_phoenix.py
       - name: Test Precomputed
-        uses: nick-fields/retry@v2.8.3
+        uses: nick-fields/retry@v2
         with:
           timeout_seconds: 15
           max_attempts: 5
           retry_on: error
-          shell: bash
           command: |
-            npm run pytest tests/test_precomputed.py
+            echo "Hello"
+            #npm run pytest tests/test_precomputed.py

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, 3.10.9, 3.11]
-        numpy-version: [1.22, 1.23, 1.24]
-        astropy-version: [4.3.1, 4.5, 4.8, 5, 5.2]
-        specutils-version: [1.6, 1.7, 1.8, 1.9]
+        python-version: [3.8, 3.11]
+        numpy-version: [1.22, 1.24]
+        astropy-version: [4.3.1, 5.2]
+        specutils-version: [1.6, 1.9]
         
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -9,10 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.11]
-        numpy-version: [1.22, 1.24]
-        astropy-version: [4.3.1, 5.2]
-        specutils-version: [1.6, 1.9]
+        python-version: [3.8, 3.9, 3.10.9, 3.11]
+        specutils-version: [1.6, 1.7, 1.8, 1.9]
         
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f docs/requirements.txt ]; then pip install -r docs/requirements.txt; fi
-          pip install astropy==${{ matrix.astropy-version }} specutils==${{ matrix.specutils-version }} numpy==${{ matrix.numpy-version }}
+          pip install specutils==${{ matrix.specutils-version }}
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/gollum-tests.yml
+++ b/.github/workflows/gollum-tests.yml
@@ -15,13 +15,13 @@ jobs:
         numpy-version: [1.21.5, 1.24]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           repository: OttoStruve/muler_example_data
           path: tests/data
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/src/gollum/experimental.py
+++ b/src/gollum/experimental.py
@@ -51,8 +51,8 @@ class ExpPHOENIXGrid(PHOENIXGrid):
             wl_lo, wl_hi = self[0].wavelength.value[0], self[0].wavelength.value[-1]
             fig = figure(
                 title="PHOENIX Interactive Dashboard",
-                plot_height=500,
-                plot_width=950,
+                height=500,
+                width=950,
                 tools="pan,wheel_zoom,box_zoom,tap,reset",
                 toolbar_location="below",
                 border_fill_color="whitesmoke",

--- a/src/gollum/phoenix.py
+++ b/src/gollum/phoenix.py
@@ -283,8 +283,8 @@ class PHOENIXGrid(SpectrumCollection):
             )
             fig = figure(
                 title="PHOENIX Interactive Dashboard",
-                plot_height=500,
-                plot_width=950,
+                height=500,
+                width=950,
                 tools="pan,wheel_zoom,box_zoom,tap,reset",
                 toolbar_location="below",
                 border_fill_color="whitesmoke",

--- a/src/gollum/phoenix.py
+++ b/src/gollum/phoenix.py
@@ -92,10 +92,9 @@ class PHOENIXSpectrum(PrecomputedSpectrum):
         wl_out = wl_orig[mask]
 
         fn = f"{base_path}/Z{Z_string}/lte{teff:05d}-{logg:0.2f}{Z_string}.PHOENIX-ACES-AGSS-COND-2011-HiRes.fits"
-        #If downloading, save to path
         flux_orig = fits.open(fn)[0].data.astype(np.float64)
         flux_native = flux_orig[mask]
-        native_flux_unit = u.erg / u.s / u.cm ** 2 / u.cm
+        native_flux_unit = u.erg / u.s / u.cm**2 / u.cm
 
         super().__init__(
             spectral_axis=wl_out * u.AA,
@@ -175,7 +174,13 @@ class PHOENIXGrid(SpectrumCollection):
                 pbar.desc = f"Processing Teff={teff}K|log(g)={logg:0.2f}|Z={Z:+0.1f}"
                 with suppress(FileNotFoundError, URLError):
                     spec = PHOENIXSpectrum(
-                        teff=teff, logg=logg, Z=Z, path=path, wl_lo=wl_lo, wl_hi=wl_hi, download=download
+                        teff=teff,
+                        logg=logg,
+                        Z=Z,
+                        path=path,
+                        wl_lo=wl_lo,
+                        wl_hi=wl_hi,
+                        download=download,
                     )
                     wavelengths.append(spec.wavelength)
                     fluxes.append(spec.flux)
@@ -242,7 +247,7 @@ class PHOENIXGrid(SpectrumCollection):
     ):  # pragma: no cover
         """Show an interactive dashboard for the PHOENIX grid;
         heavily inspired by the lightkurve .interact() method.
-        
+
         If data is used, we recommend that the grid first be truncated to it,
         with a margin of 50 Angstroms on either end of the spectral axis to allow for
         radial velocity shift and rotational broadening to operate properly.

--- a/src/gollum/precomputed_spectrum.py
+++ b/src/gollum/precomputed_spectrum.py
@@ -344,7 +344,6 @@ class PrecomputedSpectrum(Spectrum1D):
 
     def fit_continuum(self, pixel_distance=5001, polyorder=3, return_coeffs=False):
         """Finds the low frequency continuum trend using scipy's find_peaks filter and linear algebra.
-        Currently broken
 
         Parameters
         ----------
@@ -359,7 +358,7 @@ class PrecomputedSpectrum(Spectrum1D):
         -------
         spec_out : PrecomputedSpectrum
             New Spectrum object representing a fit of the continuum.
-        If ``return_coeffs`` is set to ``True``, this method will also return:
+        If `return_coeffs` is set to `True`, this method will also return:
             coeffs : np.array
                 New vector of polynomial coefficients that reproduce the trend.
         """
@@ -378,8 +377,7 @@ class PrecomputedSpectrum(Spectrum1D):
         A_matrix, A_full = np.vander(x_peaks, polyorder), np.vander(x_vector, polyorder)
 
         coeffs = np.linalg.lstsq(A_matrix, y_peaks, rcond=None)[0]
-        smooth_flux = np.dot(coeffs, A_full.T) * self.flux.unit
-        spec_out = self._copy(flux=smooth_flux)
+        spec_out = self._copy(flux=np.dot(coeffs, A_full.T) * self.flux.unit)
 
         return (spec_out, coeffs) if return_coeffs else spec_out
 

--- a/src/gollum/sonora.py
+++ b/src/gollum/sonora.py
@@ -107,7 +107,7 @@ class Sonora2017Spectrum(PrecomputedSpectrum):
 
             super().__init__(
                 spectral_axis=df_trimmed.wavelength.values * u.AA,
-                flux=df_trimmed.flux.values * u.erg / u.s / u.cm ** 2 / u.Hz,
+                flux=df_trimmed.flux.values * u.erg / u.s / u.cm**2 / u.Hz,
                 **kwargs,
             )
 
@@ -202,7 +202,7 @@ class Sonora2021Spectrum(PrecomputedSpectrum):
 
             super().__init__(
                 spectral_axis=df_trimmed.wavelength.values * u.AA,
-                flux=df_trimmed.flux.values * u.erg / u.s / u.cm ** 2 / u.Hz,
+                flux=df_trimmed.flux.values * u.erg / u.s / u.cm**2 / u.Hz,
                 **kwargs,
             )
 
@@ -461,7 +461,10 @@ class SonoraGrid(SpectrumCollection):
                 wl_lo, wl_hi = new_lo, new_hi
 
                 data_source = ColumnDataSource(
-                    data=dict(wavelength=data.wavelength.value, flux=data.flux.value,)
+                    data=dict(
+                        wavelength=data.wavelength.value,
+                        flux=data.flux.value,
+                    )
                 )
                 fig.step(
                     "wavelength",

--- a/src/gollum/telluric.py
+++ b/src/gollum/telluric.py
@@ -26,7 +26,7 @@ filterwarnings("ignore", category=RuntimeWarning)
 ## TODO: rename this to SkyCalc??
 class TelluricSpectrum(PrecomputedSpectrum):
     r"""
-    A container for a single Telluric precomputed synthetic spectrum, currently from the skycalc website at eso.org. 
+    A container for a single Telluric precomputed synthetic spectrum, currently from the skycalc website at eso.org.
 
     Parameters
     ----------
@@ -76,7 +76,7 @@ class TelluricSpectrum(PrecomputedSpectrum):
 
 class TelFitSpectrum(PrecomputedSpectrum):
     r"""
-    A container for a single TelFit precomputed synthetic spectrum. 
+    A container for a single TelFit precomputed synthetic spectrum.
 
     Parameters
     ----------
@@ -122,7 +122,7 @@ class TelFitSpectrum(PrecomputedSpectrum):
             super().__init__(*args, **kwargs)
 
     def air_to_vacuum(self):
-        """Converts a spectrum from air to vacuum  
+        """Converts a spectrum from air to vacuum
 
         Based on Morton, D. C. 1991, ApJS, 77, 119
         Returns

--- a/src/gollum/utilities.py
+++ b/src/gollum/utilities.py
@@ -12,7 +12,7 @@ def apply_numpy_mask(spec, mask):
         Object containing a spectrum
     mask : boolean mask, typically a numpy array
         The mask to apply to the spectrum
-    
+
     Returns
     -------
     masked_spec: Spectrum1D object
@@ -46,7 +46,7 @@ def _truncate(grid, wavelength_range=None, data=None):
         for truncating the grid.
     data: Spectrum1D-like
         A spectrum to which this method will match the wavelength limits
-        
+
     Returns
     -------
     truncated_spectrum: Spectrum1D-like


### PR DESCRIPTION
The Github Actions workflow has undergone an overhaul:
- Minor updates to certain actions to use newer versions
- Build matrix now only has Python 3.8 through 3.11 and `specutils` 1.6 through 1.9. Specutils depends on astropy and numpy, so someone would never pip install a `specutils` + `astropy` + `numpy` trio that weren't compatible with each other. Based on that, we just need to assess the `specutils` compatibility and we're golden
- Discovered a nice retry action and adapted it to work for gollum's test suite after some tweaking